### PR TITLE
Update CI configuration to run most jobs on docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ env:
 jobs:
   build:
     name: Build
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - docker
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust
@@ -23,7 +25,9 @@ jobs:
         run: cargo build --verbose
   test:
     name: Test
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - docker
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,7 +8,9 @@ env:
 jobs:
   format:
     name: Cargo fmt suggestions
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - docker
     permissions:
       pull-requests: write
       contents: read
@@ -27,7 +29,9 @@ jobs:
           commit-message: "Format code with rustfmt"
   clippy:
     name: Clippy warnings
-    runs-on: self-hosted
+    runs-on:
+      - self-hosted
+      - docker
     steps:
       - uses: actions/checkout@v4
       - name: Setup Rust


### PR DESCRIPTION
trying to prevent waiting times when one job starts on the slower deployment worker