### PR TITLE
Replace clippy check github action with newer fork

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -38,8 +38,6 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - uses: actions-rs/clippy-check@v1
+      - uses: clechasseur/rs-clippy-check@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings
-          name: Display clippy warnings in GitHub


### PR DESCRIPTION
avoids deprecated node12 warnings in the action runs